### PR TITLE
Use python convention for main()

### DIFF
--- a/Python/Bolt.py
+++ b/Python/Bolt.py
@@ -328,4 +328,6 @@ def main():
     except:
         if ui:
             ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Use Python syntax convention to only run main() if the file is the main file, and not being imported elsewhere